### PR TITLE
Preserve the event ordering in groupConcat

### DIFF
--- a/component/src/main/java/org/wso2/extension/siddhi/execution/string/GroupConcatFunctionExtension.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/execution/string/GroupConcatFunctionExtension.java
@@ -34,6 +34,7 @@ import org.wso2.siddhi.query.api.exception.SiddhiAppValidationException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.TreeMap;
 
@@ -146,7 +147,7 @@ public class GroupConcatFunctionExtension extends AttributeAggregator {
                         "should be a constant `'ASC'` or `'DESC'`, but found '" + value + "'.");
             }
         } else {
-            dataSet = new HashMap<>();
+            dataSet = new LinkedHashMap<>();
         }
     }
 

--- a/component/src/test/java/org/wso2/extension/siddhi/execution/string/GroupConcatFunctionExtensionTestCase.java
+++ b/component/src/test/java/org/wso2/extension/siddhi/execution/string/GroupConcatFunctionExtensionTestCase.java
@@ -73,7 +73,7 @@ public class GroupConcatFunctionExtensionTestCase {
                         eventArrived = true;
                     }
                     if (count.get() == 3) {
-                        AssertJUnit.assertEquals("null,8JU^,$%$6", event.getData(2));
+                        AssertJUnit.assertEquals("null,$%$6,8JU^", event.getData(2));
                         eventArrived = true;
                     }
                 }
@@ -126,7 +126,7 @@ public class GroupConcatFunctionExtensionTestCase {
                         eventArrived = true;
                     }
                     if (count.get() == 5) {
-                        AssertJUnit.assertEquals("CCC,BBB", event.getData(1));
+                        AssertJUnit.assertEquals("BBB,CCC", event.getData(1));
                         eventArrived = true;
                     }
                 }
@@ -181,7 +181,7 @@ public class GroupConcatFunctionExtensionTestCase {
                         eventArrived = true;
                     }
                     if (count.get() == 5) {
-                        AssertJUnit.assertEquals("CCC-BBB", event.getData(1));
+                        AssertJUnit.assertEquals("BBB-CCC", event.getData(1));
                         eventArrived = true;
                     }
                 }
@@ -236,7 +236,7 @@ public class GroupConcatFunctionExtensionTestCase {
                         eventArrived = true;
                     }
                     if (count.get() == 5) {
-                        AssertJUnit.assertEquals("CCC-BBB", event.getData(1));
+                        AssertJUnit.assertEquals("BBB-CCC", event.getData(1));
                         eventArrived = true;
                     }
                 }
@@ -376,7 +376,7 @@ public class GroupConcatFunctionExtensionTestCase {
                 "from inputStream#window.length(2)" +
                 "select symbol1, str:groupConcat(symbol1, '-', false, 'ASC1') as concatString1 " +
                 "insert into outputStream;");
-       siddhiManager.createSiddhiAppRuntime(inStreamDefinition + query);
+        siddhiManager.createSiddhiAppRuntime(inStreamDefinition + query);
     }
 
     @Test(expectedExceptions = SiddhiAppCreationException.class)

--- a/component/src/test/resources/testng.xml
+++ b/component/src/test/resources/testng.xml
@@ -40,6 +40,7 @@
             <class name="org.wso2.extension.siddhi.execution.string.TrimFunctionExtensionTestCase" />
             <class name="org.wso2.extension.siddhi.execution.string.UnhexFunctionExtensionTestCase" />
             <class name="org.wso2.extension.siddhi.execution.string.UpperFunctionExtensionTestCase" />
+            <class name="org.wso2.extension.siddhi.execution.string.GroupConcatFunctionExtensionTestCase" />
         </classes>
     </test>
 </suite>


### PR DESCRIPTION
## Purpose
Preserve the event ordering in groupConcat

## Goals
Preserve the event ordering in groupConcat

## Approach
Used LinkedHashmap instead of Hashmap in order to preserve the order

## User stories
NA

## Release note
NA

## Documentation
NA

## Training
NA

## Marketing
NA

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
NA

## Related PRs
NA

## Migrations (if applicable)
NA

## Test environment
java version "1.8.0_181"
Java(TM) SE Runtime Environment (build 1.8.0_181-b13)
Java HotSpot(TM) 64-Bit Server VM (build 25.181-b13, mixed mode)
 
## Learning
NA