### PR TITLE
Cast string error in function groupConcat

### DIFF
--- a/component/src/main/java/org/wso2/extension/siddhi/execution/string/GroupConcatFunctionExtension.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/execution/string/GroupConcatFunctionExtension.java
@@ -159,26 +159,26 @@ public class GroupConcatFunctionExtension extends AttributeAggregator {
 
     @Override
     public Object processAdd(Object o) {
-        addString((String) o);
+        addString(String.valueOf(o));
         return constructConcatString(",");
     }
 
     @Override
     public Object processAdd(Object[] objects) {
-        addString((String) objects[0]);
-        return constructConcatString((String) objects[1]);
+        addString(String.valueOf(objects[0]));
+        return constructConcatString(String.valueOf(objects[1]));
     }
 
     @Override
     public Object processRemove(Object o) {
-        removeString((String) o);
+        removeString(String.valueOf(o));
         return constructConcatString(",");
     }
 
     @Override
     public Object processRemove(Object[] objects) {
-        removeString((String) objects[0]);
-        return constructConcatString((String) objects[1]);
+        removeString(String.valueOf(objects[0]));
+        return constructConcatString(String.valueOf(objects[1]));
     }
 
     private void addString(String data) {


### PR DESCRIPTION
## Purpose
The first parameter type in function `groupConcat` is String. So if the column I need to use in function `groupConcat` is not string, I need to cast the column type to string. But there still throw an exception "Integer cannot cast to string" even I have already cast the column type to string.

Fixes #43 

## Automation tests
 - Unit tests 
   - Existing tests passes successfully 
 - Integration tests
   N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **yes**
 - Ran FindSecurityBugs plugin and verified report? **yes**
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **yes**
